### PR TITLE
Remove redundant reference to Ara3D.IO.VIM project

### DIFF
--- a/tests/Ara3D.SDK.Tests/Ara3D.SDK.Tests.csproj
+++ b/tests/Ara3D.SDK.Tests/Ara3D.SDK.Tests.csproj
@@ -24,7 +24,6 @@
     <ProjectReference Include="..\..\src\Ara3D.Logging\Ara3D.Logging.csproj" />
     <ProjectReference Include="..\..\src\Ara3D.Utils\Ara3D.Utils.csproj" />
     <ProjectReference Include="..\..\src\Ara3D.IO.BFAST\Ara3D.IO.BFAST.csproj" />
-    <ProjectReference Include="..\..\src\Ara3D.IO.VIM\Ara3D.VIM.csproj" />
     <ProjectReference Include="..\..\src\Ara3D.Utils\Ara3D.Utils.csproj" />
     <ProjectReference Include="..\..\src\Ara3D.Studio.Data\Ara3D.Studio.Data.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This is a simple cleanup in the project file to build without errors. 
I removed an outdated reference to Ara3D.VIM.csproj, which has already been replaced by the correct reference to Ara3D.IO.VIM.csproj.

There is no functional impact,  this is purely for cleanup and to remove redundant dependencies.